### PR TITLE
Update EmailDelivery module

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Modules should communicate with each other via their public APIs.
 
 Your task within the test is to implement the code that will fulfil these acceptance criteria:
 
-1. When the auction is finished, the system should send email notification using external service to the auction participants - the winner, creator and bidders:
-   1. The actual call to external HTTP service should be simulated with the `sleep(5)` call,
-   2. There is no need to build an HTML template, you can assume that it's done on the vendor's service,
+1. When the auction is finished, the system should send email notification using external service to the auction participants - the winner and bidders:
+   1. The actual call to external email service is simulated with the `sleep(5)` call in the `EmailDelivery` module (there is **no need** to call any email service nor send via SMPT),
+   2. There is no need to build an HTML template or email content, you can assume that it's done on the vendor's service (it only needs template variables),
    3. The auction winner should receive data about the order that was created (its `reference_number` and `total_payment`),
-   4. Other participants should receive information about the winner and the highest bid.
+   4. Other participants should receive information about the highest bid.
 2. When selecting the shipping method, a total order price should be calculated with added shipping cost:
    1. When shipping method A is selected, then the shipping price should be equal to weight rounded up to 1kg times $2,
    2. When shipping method B is selected, when the shipping price should be equal to package volume (in m3) times an id field fetched from https://official-joke-api.appspot.com/random_joke.

--- a/lib/email_delivery/actions/deliver.rb
+++ b/lib/email_delivery/actions/deliver.rb
@@ -9,10 +9,10 @@ module EmailDelivery
         end
       end
 
-      def initialize(email_address:, subject:, content:)
+      def initialize(email_address:, subject:, variables:)
         @email_address = email_address
         @subject = subject
-        @content = content
+        @variables = variables
       end
 
       # Temporarily simulating an expensive email delivery action
@@ -22,7 +22,7 @@ module EmailDelivery
 
       private
 
-      attr_reader :email_address, :subject, :content
+      attr_reader :email_address, :subject, :variables
     end
   end
 end

--- a/lib/email_delivery/api/email.rb
+++ b/lib/email_delivery/api/email.rb
@@ -6,9 +6,9 @@ module EmailDelivery
       class << self
         # @param email_address [String] Email address for the message
         # @param subject [String] Subject of the message
-        # @param content [String] Body of the message
-        def deliver(email_address, subject, content)
-          ::EmailDelivery::Actions::Deliver.call(email_address: email_address, subject: subject, content: content)
+        # @param variables [Hash] Variables to be used in the template (f.e. name, shipping_address)
+        def deliver(email_address, subject, variables)
+          ::EmailDelivery::Actions::Deliver.call(email_address: email_address, subject: subject, variables: variables)
         end
       end
     end


### PR DESCRIPTION
- Change `content` param to `variables` for the EmailDelivery API and DeliverAction - in the task we say that we don't need any content for the email.
- Make the first task requirements more explicit and limit requirements